### PR TITLE
Use `ADD --chmod=755`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.
 RUN flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 RUN flatpak remote-add --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
 
-ADD https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client /usr/bin
-RUN chmod +x /usr/bin/flat-manager-client
+ADD --chmod=755 https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client /usr/bin


### PR DESCRIPTION
This is practically an undocumented feature of BuildKit, but it avoids making another copy of the script to another layer.

https://github.com/moby/buildkit/pull/1492