### PR TITLE
Add image generation with aarch64 runtimes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ jobs:
 
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         runtime:
           - name: freedesktop-21.08
             packages: org.freedesktop.Platform//21.08 org.freedesktop.Sdk//21.08
@@ -103,13 +104,26 @@ jobs:
           # syntax = docker/dockerfile:experimental
           FROM localhost:5000/fedora-base:latest
 
-          RUN --security=insecure flatpak install -y --noninteractive ${{matrix.runtime.remote}} ${{ matrix.runtime.packages }}
+          RUN --security=insecure flatpak install -y --noninteractive --arch=${{ matrix.arch }} ${{ matrix.runtime.remote }} ${{ matrix.runtime.packages }}
 
-      - name: Build & push the ${{ matrix.runtime.name }} image to Docker Hub
+      - name: Build & push the ${{ matrix.runtime.name }}-x86_64 image to Docker Hub
+        if: ${{ matrix.arch == 'x86_64' }}
         uses: docker/build-push-action@v2.2.2
         with:
           allow: security.insecure
           context: .
           file: ${{ matrix.runtime.name }}.Dockerfile
           push: true
-          tags: bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}
+          tags: |
+            bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}
+            bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}-x86_64
+      
+      - name: Build & push the ${{ matrix.runtime.name }}-${{ matrix.arch }} image to Docker Hub
+        if: ${{ matrix.arch != 'x86_64' }}
+        uses: docker/build-push-action@v2.2.2
+        with:
+          allow: security.insecure
+          context: .
+          file: ${{ matrix.runtime.name }}.Dockerfile
+          push: true
+          tags: bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}-${{ matrix.arch }}

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -8,13 +8,13 @@ jobs:
   flatpak-builder:
     name: Flatpak Builder
     runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
-      options: --privileged
     strategy:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40-${{ matrix.arch }}
+      options: --privileged
     steps:
       - uses: actions/checkout@v2
       - name: Install QEMU deps

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ jobs:
   flatpak:
     name: "Flatpak"
     runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
-      options: --privileged
     strategy:
       matrix:
         arch: [x86_64, aarch64]
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40-${{ matrix.arch }}
+      options: --privileged
     steps:
     - uses: actions/checkout@v2
     # Docker is required by the docker/setup-qemu-action which enables emulation


### PR DESCRIPTION
When using the builder action with aarch64 as arch, the action always install aarch64 runtime.

To avoid this, generating x86_64 images with aarch64 runtime is a solution.

Making images per runtime architecture avoid to make images bigger in size.

Images are tagged with a tag suffixed with the runtime arch, this allow using matrix with containers.
x86_64 runtime images are still also tagged with a non-suffixed tag.

This PR was not tested and two of the checks are failing because images with new tags do not exist.