### PR TITLE
flatpak-builder: Add 'upload-artifact' and 'artifact-name' inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ jobs:
 | `cache-key` | Specifies the cache key. CPU arch is automatically added, so there is no need to add it to the cache key. | Optional | `flatpak-builder-${sha256(manifestPath)}` |
 | `arch` | Specifies the CPU architecture to build for | Optional | `x86_64` |
 | `mirror-screenshots-url` | Specifies the URL to mirror screenshots | Optional | - |
+| `upload-artifact` | Enable/Disable uploading the `.flatpak` as a GitHub Actions artifact | Optional | `true` |
+| `artifact-name` | The GitHub Actions artifact name  | Optional | `${bundle}-${arch}` |
 
 #### Building for multiple CPU architectures
 

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -54,6 +54,17 @@ inputs:
     description: >
       The URL to mirror screenshots.
     required: false
+  upload-artifact:
+    description: >
+      Toggles uploading the .flatpak as a GitHub Actions artifact.
+      Possible values: true, enabled, yes, y. Or something else to disable it.
+    default: "true"
+    required: false
+  artifact-name:
+    description: >
+      The name to use when uploading a GitHub Actions artifact.
+      Defaults to ${bundle}-${arch}
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"


### PR DESCRIPTION
#### New flatpak-builder inputs:

| Name | Description | Required | Default |
| ---     | ----------- | ----------- |----|
| `upload-artifact` | Enable/Disable uploading the `.flatpak` as a GitHub Actions artifact | Optional | `true` |
| `artifact-name` | The GitHub Actions artifact name  | Optional | `${bundle}-${arch}` |

@bilelmoussaoui: This is just a quick PR to tee up the idea. Please feel free to edit / refactor as desired.

EDIT: Also, a quick first attempt at following the instructions in https://github.com/flatpak/flatpak-github-actions/blob/master/CONTRIBUTING.md yielded massive (unexpected) differences in the output file - so I omitted that.