### PR TITLE
Update README.md with flatpak/flatpak-github-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,7 @@ In the example below, the manifest is located at `/build-aux/flatpak/org.gnome.z
         "--share=ipc",
         "--device=dri",
         "--socket=fallback-x11",
-        "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--socket=wayland"
     ],
     "modules" : [
         {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flatpak Github Actions
 
-![CI](https://github.com/bilelmoussaoui/flatpak-github-actions/workflows/CI/badge.svg)
+![CI](https://github.com/flatpak/flatpak-github-actions/workflows/CI/badge.svg)
 
 Build and deploy your Flatpak application using Github Actions
 
@@ -29,7 +29,7 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: palette.flatpak
         manifest-path: org.gnome.zbrown.Palette.yml
@@ -86,7 +86,7 @@ jobs:
       uses: docker/setup-qemu-action@v1
       with:
         platforms: arm64
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: palette.flatpak
         manifest-path: org.gnome.zbrown.Palette.yml
@@ -159,13 +159,13 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
       name: "Build"
       with:
         bundle: palette.flatpak
         manifest-path: org.gnome.zbrown.Palette.yml
         cache-key: flatpak-builder-${{ github.sha }}
-    - uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v3
+    - uses: flatpak/flatpak-github-actions/flat-manager@v4
       name: "Deploy"
       with:
         repository: elementary


### PR DESCRIPTION
Instead of using the action from Bilal's namespace. The images are still pointing to Bilal's Dockerhub, but that needs porting to GitHub Registry before updating the README.