### PR TITLE
Dockerfile: Install git-lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN dnf update -y && \
-    dnf install -y dbus-daemon flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gobject xorg-x11-server-Xvfb ccache zstd && \
+    dnf install -y dbus-daemon flatpak flatpak-builder git-lfs python3-aiohttp python3-tenacity python3-gobject xorg-x11-server-Xvfb ccache zstd && \
     dnf clean all
 
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
Install git-lfs alongside other dependencies, since some repositories might need LFS to pull and init correctly.

Closes https://github.com/flatpak/flatpak-github-actions/issues/90