### PR TITLE
ci: Build a base image and push to GitHub Packages

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,41 @@
+on:
+  schedule:
+    - cron: "0 0 * * */7" # This should run every hour
+  workflow_dispatch:
+
+name: Container Images
+
+jobs:
+  base-image:
+    name: Base Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # set latest tag for main branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+
+      - name: Login
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          file: Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,10 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf update -y && \
+    dnf install -y flatpak flatpak-builder git-lfs ccache zstd \
+                   python3-aiohttp python3-tenacity python3-gobject \
+                   dbus-daemon xorg-x11-server-Xvfb && \
+    dnf clean all && rm -rf /var/cache/dnf
+
+ADD https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client /usr/bin
+RUN chmod +x /usr/bin/flat-manager-client


### PR DESCRIPTION
Add a new container image to be used as a base image for GitHub actions. Add a workflow that builds and pushs the image to ghcr.io instead of docker.io

closes #60