### PR TITLE
build: update actions to node16

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -61,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: "14"
+          node-version: "16"
       - run: yarn install --also=dev
         working-directory: flatpak-builder
       - run: yarn run eslint .

--- a/flat-manager/action.yml
+++ b/flat-manager/action.yml
@@ -26,5 +26,5 @@ inputs:
       "Mark new refs as end-of-life. This one takes an ID that supersedes the current one. By the user's request, the application data may be preserved for the new application. Note, this is actually a prefix match, so if you say org.the.app=org.new.app, then something like org.the.app.Locale will be rebased to org.new.app.Locale."
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -55,5 +55,5 @@ inputs:
       The URL to mirror screenshots.
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
node12 GitHub Actions are now deprecated, and we can port to node16 without any problems.