### PR TITLE
dockerfile: Add libappstream-glib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 RUN dnf update -y && \
-    dnf install -y dbus-daemon flatpak flatpak-builder git-lfs python3-aiohttp python3-tenacity python3-gobject xorg-x11-server-Xvfb ccache zstd && \
+    dnf install -y dbus-daemon flatpak flatpak-builder git-lfs python3-aiohttp python3-tenacity python3-gobject xorg-x11-server-Xvfb ccache zstd libappstream-glib && \
     dnf clean all
 
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
Since libappstream-glib is no longer a dependency of flatpak in fedora 37, it isn't in the built image. It is useful to be able to run appstream-util to verify metainfo after the flatpak build, so explicitly install libappstream-glib which provides appstream-util.