### PR TITLE
Update versions in CI

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,7 +9,7 @@ jobs:
   codespell:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ name: Codespell
 
 jobs:
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,15 +85,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.1.1
+        uses: docker/setup-buildx-action@v2.2.1
         with:
           driver-opts: network=host
 
       - name: Cache Docker layers for the base image
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.0
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -101,7 +101,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build & push the Fedora base image to local registry
-        uses: docker/build-push-action@v2.2.2
+        uses: docker/build-push-action@v3.2.0
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -112,7 +112,7 @@ jobs:
           tags: localhost:5000/fedora-base:latest
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1.8.0
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
           RUN --security=insecure flatpak install -y --noninteractive ${{matrix.runtime.remote}} ${{ matrix.runtime.packages }}
 
       - name: Build & push the ${{ matrix.runtime.name }} image to Docker Hub
-        uses: docker/build-push-action@v2.2.2
+        uses: docker/build-push-action@v3.2.0
         with:
           allow: security.insecure
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ name: Docker images
 jobs:
   build-images:
     name: Build & push Docker images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install QEMU deps
         if: ${{ matrix.arch != 'x86_64' }}
         run: |
           dnf -y install docker
       - name: Set up QEMU
         if: ${{ matrix.arch != 'x86_64' }}
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
       - uses: ./flatpak-builder
@@ -46,9 +46,9 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --also=dev
@@ -60,9 +60,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
       - run: yarn install --also=dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 If you plan to contribute to flatpak-github-actions, here's a couple of things that could help you get started.
 
 ## Prerequisites
-- NodeJS 12.x or newer
+- NodeJS 16.x or newer
 - Yarn
 - `vercel/ncc` you can install it with `yarn global add vercel/ncc` 
 


### PR DESCRIPTION
This PR basically contains:
- Actions versions update to replace deprecated NodeJS v12 with minimum v16 — the v12 is deprecated and GitHub Actions raises warnings ([example](https://github.com/flatpak/flatpak-github-actions/actions/runs/3722639780))
- CONTRIBUTING.md change with NodeJS v12 bump to v16 for the same reason
- Update runtime image ubuntu-20.04 to ubuntu-22.04 (btw, ubuntu-latest is now ubuntu-22.04)

Some notes:
- Some actions were very out of date, and I was able to successfully test "flatpatk-test.yml" (name: CI), but not "docker.yml" (name: Docker images). So I can't assure it is working just the same with newest action versions, although the syntax and versions are correct and the latest.
- Is elementary-juno image really necessary in docker-image.yml? Their [Continuous Integration doc](https://docs.elementary.io/develop/writing-apps/our-first-app/continuous-integration) points to their own container image and their [Packaging doc](https://docs.elementary.io/develop/writing-apps/our-first-app/packaging) points to other runtime version.
