### PR TITLE
Add a restore-cache option

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -16,9 +16,14 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
         cache: [use-cache, no-cache]
+        restore: [cache-restored, no-cache-restored]
         exclude:
           - arch: aarch64
             cache: no-cache
+          - arch: aarch64
+            restore: no-cache-restored
+          - cache: no-cache
+            restore: cache-restored
     steps:
       - uses: actions/checkout@v3
       - name: Install QEMU deps
@@ -32,10 +37,11 @@ jobs:
           platforms: arm64
       - uses: ./flatpak-builder
         with:
-          bundle: org.example.MyApp.Devel-${{ matrix.cache }}.flatpak
+          bundle: org.example.MyApp.Devel-${{ matrix.cache }}-${{ matrix.restore }}.flatpak
           manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
           cache: ${{ matrix.cache == 'use-cache' }}
-          cache-key: flatpak-builder-${{ github.sha }}
+          restore-cache: ${{ matrix.restore == 'cache-restored' }}
+          cache-key: flatpak-builder-${{ github.sha }}-${{ matrix.restore }}
           arch: ${{ matrix.arch }}
       # TODO: setup a flat-manager before and use it later here
       #- uses: ./flat-manager
@@ -71,7 +77,7 @@ jobs:
         with:
           bundle: org.example.MyApp.Devel-cache-hit.flatpak
           manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ github.sha }}-no-cache-restored
 
   tests:
     name: Tests

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
 | `run-tests` | Enable/Disable running tests. This overrides the `flatpak-builder` option of the same name, which invokes `make check` or `ninja test`. Network and X11 access is enabled, with a display server provided by `xvfb-run`.  | Optional | `false` |
 | `branch` | The default flatpak branch  | Optional | `master` |
 | `cache` | Enable/Disable caching `.flatpak-builder` directory | Optional | `true` |
+| `restore-cache` | Enable/Disable cache restoring. If caching is enabled. | Optional | `true` |
 | `cache-key` | Specifies the cache key. CPU arch is automatically added, so there is no need to add it to the cache key. | Optional | `flatpak-builder-${sha256(manifestPath)}` |
 | `arch` | Specifies the CPU architecture to build for | Optional | `x86_64` |
 | `mirror-screenshots-url` | Specifies the URL to mirror screenshots | Optional | - |

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -45,6 +45,12 @@ inputs:
       Possible values: true, enabled, yes, y. Or something else to disable it.
     default: "true"
     required: false
+  restore-cache:
+    description: >
+      Toggles restoring the cache.
+      Possible values: true, enabled, yes, y. Or something else to disable it.
+    default: "true"
+    required: false
   cache-key:
     description: >
       Defines the cache-key to use.

--- a/flatpak-builder/dist/index.js
+++ b/flatpak-builder/dist/index.js
@@ -230,10 +230,11 @@ const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, 
  * @param {string} repositoryName the repository name to install the runtime from
  * @param {string} repositoryUrl the repository url
  * @param {Boolean} cacheBuildDir whether to cache the build dir or not
+ * @param {Boolean} restoreCache whether to restore the cache of the build dir or not
  * @param {string} cacheKey the default cache key if there are any
  * @returns {Promise<String>} the cacheHitKey if a cache was hit
  */
-const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheKey) => {
+const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, restoreCache, cacheKey) => {
   /// If the user has set a different runtime source
   if (repositoryUrl !== 'https://flathub.org/repo/flathub.flatpakrepo') {
     await exec.exec('flatpak', ['remote-add', '--if-not-exists', repositoryName, repositoryUrl])
@@ -241,7 +242,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheK
 
   // Restore the cache in case caching is enabled
   let cacheHitKey
-  if (cacheBuildDir) {
+  if (cacheBuildDir && restoreCache) {
     cacheHitKey = await cache.restoreCache(
       CACHE_PATH,
       `${cacheKey}`,
@@ -272,6 +273,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheK
  * @param {string} buildDir Where to build the application
  * @param {string} localRepoName The flatpak repository name
  * @param {boolean} cacheBuildDir Whether to enable caching the build directory
+ * @param {boolean} restoreCache Whether to restore the cache or not
  * @param {string} cacheKey the default cache key if there are any
  * @param {string} arch The CPU architecture to build for
  * @param {string} mirrorScreenshotsUrl The URL to mirror screenshots
@@ -287,6 +289,7 @@ const run = async (
   buildDir,
   localRepoName,
   cacheBuildDir,
+  restoreCache,
   cacheKey,
   arch,
   mirrorScreenshotsUrl
@@ -304,7 +307,7 @@ const run = async (
 
   let cacheHitKey
   try {
-    cacheHitKey = await prepareBuild(repositoryName, repositoryUrl, cacheBuildDir, cacheKey)
+    cacheHitKey = await prepareBuild(repositoryName, repositoryUrl, cacheBuildDir, restoreCache, cacheKey)
   } catch (err) {
     core.setFailed(`Failed to prepare the build ${err}`)
   }
@@ -376,6 +379,7 @@ if (require.main === require.cache[eval('__filename')]) {
     'flatpak_app',
     'repo',
     ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('cache')),
+    ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('restore-cache')),
     core.getInput('cache-key'),
     core.getInput('arch'),
     core.getInput('mirror-screenshots-url')

--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -224,10 +224,11 @@ const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, 
  * @param {string} repositoryName the repository name to install the runtime from
  * @param {string} repositoryUrl the repository url
  * @param {Boolean} cacheBuildDir whether to cache the build dir or not
+ * @param {Boolean} restoreCache whether to restore the cache of the build dir or not
  * @param {string} cacheKey the default cache key if there are any
  * @returns {Promise<String>} the cacheHitKey if a cache was hit
  */
-const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheKey) => {
+const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, restoreCache, cacheKey) => {
   /// If the user has set a different runtime source
   if (repositoryUrl !== 'https://flathub.org/repo/flathub.flatpakrepo') {
     await exec.exec('flatpak', ['remote-add', '--if-not-exists', repositoryName, repositoryUrl])
@@ -235,7 +236,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheK
 
   // Restore the cache in case caching is enabled
   let cacheHitKey
-  if (cacheBuildDir) {
+  if (cacheBuildDir && restoreCache) {
     cacheHitKey = await cache.restoreCache(
       CACHE_PATH,
       `${cacheKey}`,
@@ -266,6 +267,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheK
  * @param {string} buildDir Where to build the application
  * @param {string} localRepoName The flatpak repository name
  * @param {boolean} cacheBuildDir Whether to enable caching the build directory
+ * @param {boolean} restoreCache Whether to restore the cache or not
  * @param {string} cacheKey the default cache key if there are any
  * @param {string} arch The CPU architecture to build for
  * @param {string} mirrorScreenshotsUrl The URL to mirror screenshots
@@ -281,6 +283,7 @@ const run = async (
   buildDir,
   localRepoName,
   cacheBuildDir,
+  restoreCache,
   cacheKey,
   arch,
   mirrorScreenshotsUrl
@@ -298,7 +301,7 @@ const run = async (
 
   let cacheHitKey
   try {
-    cacheHitKey = await prepareBuild(repositoryName, repositoryUrl, cacheBuildDir, cacheKey)
+    cacheHitKey = await prepareBuild(repositoryName, repositoryUrl, cacheBuildDir, restoreCache, cacheKey)
   } catch (err) {
     core.setFailed(`Failed to prepare the build ${err}`)
   }
@@ -370,6 +373,7 @@ if (require.main === module) {
     'flatpak_app',
     'repo',
     ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('cache')),
+    ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('restore-cache')),
     core.getInput('cache-key'),
     core.getInput('arch'),
     core.getInput('mirror-screenshots-url')


### PR DESCRIPTION
I created this option to avoid downloading and restoring a cache that may not help the build at all (e.g. another architecture) and only lose time (depending on cache size and github network speed).

If we check the existence of a cache matching with the cache key or if the manifest was modified beforehand through another workflow step, this option will allow to skip restoring a non-matching cache.