### PR TITLE
Avoid caching if key and hit key are identical

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -15,6 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
+        cache: [use-cache, no-cache]
+        exclude:
+          - arch: aarch64
+            cache: no-cache
     steps:
       - uses: actions/checkout@v3
       - name: Install QEMU deps
@@ -28,8 +32,9 @@ jobs:
           platforms: arm64
       - uses: ./flatpak-builder
         with:
-          bundle: org.example.MyApp.Devel.flatpak
+          bundle: org.example.MyApp.Devel-${{ matrix.cache }}.flatpak
           manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
+          cache: ${{ matrix.cache == 'use-cache' }}
           cache-key: flatpak-builder-${{ github.sha }}
           arch: ${{ matrix.arch }}
       # TODO: setup a flat-manager before and use it later here
@@ -52,6 +57,21 @@ jobs:
           manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
           stop-at-module: testproject
           cache: false
+
+  flatpak-builder-cache-hit:
+    name: Flatpak Builder Cache Hit
+    runs-on: ubuntu-latest
+    needs: flatpak-builder
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./flatpak-builder
+        with:
+          bundle: org.example.MyApp.Devel-cache-hit.flatpak
+          manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
+          cache-key: flatpak-builder-${{ github.sha }}
 
   tests:
     name: Tests

--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -163,10 +163,11 @@ const getModifiedManifestPath = manifestPath => {
  * @param {string} localRepoName The flatpak repository name
  * @param {boolean} cacheBuildDir Whether to enable caching the build directory
  * @param {string} cacheKey The key used to cache the build directory
+ * @param {string} cacheHitKey The key used to restore the build directory
  * @param {string} arch The CPU architecture to build for
  * @param {string} mirrorScreenshotsUrl The URL to mirror screenshots
  */
-const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl) => {
+const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, cacheHitKey, arch, mirrorScreenshotsUrl) => {
   const appId = manifest['app-id'] || manifest.id
   const branch = manifest.branch || core.getInput('branch') || 'master'
 
@@ -192,7 +193,7 @@ const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, 
   args.push(buildDir, manifestPath)
 
   await exec.exec('xvfb-run --auto-servernum flatpak-builder', args)
-  if (cacheBuildDir) {
+  if (cacheBuildDir && (cacheKey !== cacheHitKey)) {
     await cache.saveCache(
       CACHE_PATH,
       cacheKey
@@ -222,28 +223,22 @@ const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, 
  *
  * @param {string} repositoryName the repository name to install the runtime from
  * @param {string} repositoryUrl the repository url
- * @param {PathLike} manifestPath the manifest path
  * @param {Boolean} cacheBuildDir whether to cache the build dir or not
  * @param {string} cacheKey the default cache key if there are any
- * @param {string} arch The CPU architecture to build for
- * @returns {Promise<String>} the new cacheKey if none was set before
+ * @returns {Promise<String>} the cacheHitKey if a cache was hit
  */
-const prepareBuild = async (repositoryName, repositoryUrl, manifestPath, cacheBuildDir, cacheKey, arch) => {
+const prepareBuild = async (repositoryName, repositoryUrl, cacheBuildDir, cacheKey) => {
   /// If the user has set a different runtime source
   if (repositoryUrl !== 'https://flathub.org/repo/flathub.flatpakrepo') {
     await exec.exec('flatpak', ['remote-add', '--if-not-exists', repositoryName, repositoryUrl])
   }
 
   // Restore the cache in case caching is enabled
+  let cacheHitKey
   if (cacheBuildDir) {
-    if (!cacheKey) {
-      const manifestHash = (await computeHash(manifestPath)).substring(0, 20)
-      cacheKey = `flatpak-builder-${manifestHash}`
-    }
-
-    const cacheHitKey = await cache.restoreCache(
+    cacheHitKey = await cache.restoreCache(
       CACHE_PATH,
-      `${cacheKey}-${arch}`,
+      `${cacheKey}`,
       [
         'flatpak-builder-',
         'flatpak-'
@@ -255,8 +250,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, manifestPath, cacheBu
       core.info('No cache was found')
     }
   }
-  // Ensure the cache key is unique if we're building multiple architectures in the same job
-  return `${cacheKey}-${arch}`
+  return cacheHitKey
 }
 
 /**
@@ -291,8 +285,20 @@ const run = async (
   arch,
   mirrorScreenshotsUrl
 ) => {
+  if (cacheBuildDir && !cacheKey) {
+    try {
+      const manifestHash = (await computeHash(manifestPath)).substring(0, 20)
+      cacheKey = `flatpak-builder-${manifestHash}`
+    } catch (err) {
+      core.setFailed(`Fail to create create cache key based on manifest hash: ${err}`)
+    }
+  }
+  // Ensure the cache key is unique if we're building multiple architectures in the same job
+  cacheKey = `${cacheKey}-${arch}`
+
+  let cacheHitKey
   try {
-    cacheKey = await prepareBuild(repositoryName, repositoryUrl, manifestPath, cacheBuildDir, cacheKey, arch)
+    cacheHitKey = await prepareBuild(repositoryName, repositoryUrl, cacheBuildDir, cacheKey)
   } catch (err) {
     core.setFailed(`Failed to prepare the build ${err}`)
   }
@@ -312,7 +318,7 @@ const run = async (
       return saveManifest(modifiedManifest, modifiedManifestPath)
     })
     .then((manifest) => {
-      return build(manifest, modifiedManifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl)
+      return build(manifest, modifiedManifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, cacheHitKey, arch, mirrorScreenshotsUrl)
     })
     .then(() => {
       if (dbusSession) {


### PR DESCRIPTION
- Moves the code cache key "generation" before calling `prepareBuild()`
- Makes `prepareBuild()` return the cache hit key
- Compares the key and the hit key in `build()` to check if caching is needing (if enabled)
- No more caching error because of an already used key when the given key was hit while restoring.
- Avoid creating a cache on the PR branch while the cache already exist on the default branch (master).
![Screenshot from 2023-03-18 18-14-01](https://user-images.githubusercontent.com/17492366/226122512-f1b7c950-a2a2-4017-9699-095addce156d.png)


Edit: Sorry for the CI spam.