### PR TITLE
Add a stop-at-module option

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -39,6 +39,20 @@ jobs:
       #    flat-manager-url: https://flatpak-api.elementary.io
       #    token: some_very_hidden_token
 
+  flatpak-builder-stop-at:
+    name: Flatpak Builder Stop At
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./flatpak-builder
+        with:
+          manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
+          stop-at-module: testproject
+          cache: false
+
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ jobs:
 | Name | Description | Required | Default |
 | ---     | ----------- | ----------- |----|
 | `manifest-path` | The relative path of the manifest file  | Required | - |
+| `stop-at-module` | Stop at the specified module, ignoring it and all the following ones. Using this option disables generating bundles. | Optional | Build all modules from the manifest file |
 | `bundle` | The bundle name  | Optional | `app.flatpak` |
 | `build-bundle` | Whether to build a bundle or not | Optional | `true` |
 | `repository-name` | The repository name, used to fetch the runtime when the user download the Flatpak bundle or when building the application  | Optional | `flathub` |

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -8,6 +8,11 @@ inputs:
   manifest-path:
     description: "The relative path of the manifest file."
     required: true
+  stop-at-module:
+    description: >
+      Stop at the specified module, ignoring it and all the following ones.
+      Using this option enforces `build-bundle` to false.
+    required: false
   bundle:
     description: "The bundle name, by default it's app.flatpak"
     required: false

--- a/flatpak-builder/dist/index.js
+++ b/flatpak-builder/dist/index.js
@@ -160,6 +160,7 @@ const getModifiedManifestPath = manifestPath => {
  *
  * @param {object} manifest A flatpak manifest
  * @param {object} manifestPath The flatpak manifest path
+ * @param {string} stopAtModule The module where the build should stop
  * @param {string} bundle The bundle's name
  * @param {boolean} buildBundle Whether to build a bundle or not
  * @param {string} repositoryUrl The repository used to install the runtime from
@@ -171,7 +172,7 @@ const getModifiedManifestPath = manifestPath => {
  * @param {string} arch The CPU architecture to build for
  * @param {string} mirrorScreenshotsUrl The URL to mirror screenshots
  */
-const build = async (manifest, manifestPath, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl) => {
+const build = async (manifest, manifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl) => {
   const appId = manifest['app-id'] || manifest.id
   const branch = manifest.branch || core.getInput('branch') || 'master'
 
@@ -191,6 +192,9 @@ const build = async (manifest, manifestPath, bundle, buildBundle, repositoryUrl,
   if (mirrorScreenshotsUrl) {
     args.push(`--mirror-screenshots-url=${mirrorScreenshotsUrl}`)
   }
+  if (stopAtModule) {
+    args.push(`--stop-at=${stopAtModule}`)
+  }
   args.push(buildDir, manifestPath)
 
   await exec.exec('xvfb-run --auto-servernum flatpak-builder', args)
@@ -203,7 +207,7 @@ const build = async (manifest, manifestPath, bundle, buildBundle, repositoryUrl,
     })
   }
 
-  if (buildBundle) {
+  if (buildBundle && !stopAtModule) {
     core.info('Creating a bundle...')
     await exec.exec('flatpak', [
       'build-bundle',
@@ -265,6 +269,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, manifestPath, cacheBu
  * Run a complete build
  *
  * @param {object} manifestPath The flatpak manifest path
+ * @param {string} stopAtModule The module where the build should stop
  * @param {boolean} runTests Whether to run tests or not
  * @param {string} bundle The bundle's name
  * @param {boolean} buildBundle Whether to build a bundle or not
@@ -279,6 +284,7 @@ const prepareBuild = async (repositoryName, repositoryUrl, manifestPath, cacheBu
  */
 const run = async (
   manifestPath,
+  stopAtModule,
   runTests,
   bundle,
   buildBundle,
@@ -312,7 +318,7 @@ const run = async (
       return saveManifest(modifiedManifest, modifiedManifestPath)
     })
     .then((manifest) => {
-      return build(manifest, modifiedManifestPath, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl)
+      return build(manifest, modifiedManifestPath, stopAtModule, bundle, buildBundle, repositoryUrl, repositoryName, buildDir, localRepoName, cacheBuildDir, cacheKey, arch, mirrorScreenshotsUrl)
     })
     .then(() => {
       if (dbusSession) {
@@ -320,7 +326,7 @@ const run = async (
         dbusSession = null
       }
 
-      if (!buildBundle) {
+      if (!buildBundle || stopAtModule) {
         return
       }
 
@@ -355,6 +361,7 @@ module.exports = {
 if (require.main === require.cache[eval('__filename')]) {
   run(
     core.getInput('manifest-path'),
+    core.getInput('stop-at-module'),
     ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('run-tests')),
     core.getInput('bundle') || 'app.flatpak',
     ['y', 'yes', 'true', 'enabled', true].includes(core.getInput('build-bundle')),


### PR DESCRIPTION
Rather than modifying the manifest to only build dependencies, @GeorgesStavracas recommended me to use the flatpak-builder `--stop-at=` option by implementing it in the action.

When the option is used, it disables generating the bundle.

This option purpose:
- Build and cache dependencies for long CI run (QEMU aarch64)
- Potentially partial test build