### PR TITLE
flatpak-builder: Add --socket=session-bus if tests are enabled

### DIFF
--- a/flatpak-builder/dist/index.js
+++ b/flatpak-builder/dist/index.js
@@ -128,6 +128,7 @@ const modifyManifest = (manifest, runTests = false, testEnv = {}) => {
     const testArgs = [
       '--socket=x11',
       '--share=network',
+      '--socket=session-bus',
       ...(buildOptions['test-args'] || [])
     ]
 

--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -122,6 +122,7 @@ const modifyManifest = (manifest, runTests = false, testEnv = {}) => {
     const testArgs = [
       '--socket=x11',
       '--share=network',
+      '--socket=session-bus',
       ...(buildOptions['test-args'] || [])
     ]
 

--- a/flatpak-builder/tests/parser.test.js
+++ b/flatpak-builder/tests/parser.test.js
@@ -23,7 +23,7 @@ test('The manifest should be modified correctly if tests are enabled', async () 
   const modifiedManifest = modifyManifest(manifest, true)
 
   expect(modifiedManifest['build-options']).toEqual({
-    'test-args': ['--socket=x11', '--share=network'],
+    'test-args': ['--socket=x11', '--share=network', '--socket=session-bus'],
     env: {
       DISPLAY: '0:0'
     }
@@ -40,7 +40,7 @@ test('The manifest should be modified correctly if tests are enabled & has a bui
   expect(modifiedManifest['build-options']).toEqual({
     'append-path': '/usr/lib/sdk/rust-stable/bin',
     'build-args': ['--share=network'],
-    'test-args': ['--socket=x11', '--share=network'],
+    'test-args': ['--socket=x11', '--share=network', '--socket=session-bus'],
     env: {
       DISPLAY: '0:0',
       CARGO_HOME: '/run/build/contrast/cargo',


### PR DESCRIPTION
TLDR: Now that this action supports DBus for tests, I am trying to switch to it for Flatseal, but I can't seem to make it work. 

I haven't really found the issue yet, but, while trying to mimic what this action does locally, I noticed I had to add to `--socket=session-bus` to the tests-args in my manifest to make it work.  So, I am putting this here in case it's really needed.

See https://github.com/tchx84/Flatseal/pull/514