### PR TITLE
Bump dependencies

### DIFF
--- a/flat-manager/package.json
+++ b/flat-manager/package.json
@@ -3,8 +3,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.7",
-    "@actions/exec": "^1.0.4"
+    "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^8.37.0",


### PR DESCRIPTION
Fixes #130.

[GitHub Actions has deprecated save-state and set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and will fully disable them on May 31, 2023. The recommended action is to update `@actions/core` to 1.10.0. While this was already done in flatpak-builder, and it appears to have been done in flat-manager in `flat-manager/yarn.lock`, let's still explicitly set this in `flat-manager/package.json` as well. Also, let's match the values to the values in `flatpak-builder/package.json`.