### PR TITLE
CI, README: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,7 +9,7 @@ jobs:
   codespell:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -25,7 +25,7 @@ jobs:
           - cache: no-cache
             restore: cache-restored
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install QEMU deps
         if: ${{ matrix.arch != 'x86_64' }}
         run: |
@@ -58,7 +58,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./flatpak-builder
         with:
           manifest-path: ./flatpak-builder/tests/test-project/org.example.MyApp.yaml
@@ -74,7 +74,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./flatpak-builder
         with:
           bundle: org.example.MyApp.Devel-cache-hit.flatpak
@@ -89,7 +89,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -103,7 +103,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
       with:
         bundle: palette.flatpak
@@ -83,7 +83,7 @@ jobs:
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Docker is required by the docker/setup-qemu-action which enables emulation
     - name: Install deps
       if: ${{ matrix.arch != 'x86_64' }}
@@ -163,7 +163,7 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
       name: "Build"
       with:


### PR DESCRIPTION
This PR bumps the `actions/checkout` version from v3 (Node 16) to v4 (Node 20) as Node 16 is reaching eol soon.
Ref. <https://nodejs.org/en/blog/announcements/nodejs16-eol>.