### PR TITLE
action: bump runner to node20

### DIFF
--- a/flat-manager/action.yml
+++ b/flat-manager/action.yml
@@ -31,5 +31,5 @@ inputs:
     required: false
     default: "false"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/flatpak-builder/action.yml
+++ b/flatpak-builder/action.yml
@@ -79,5 +79,5 @@ inputs:
     required: false
     default: "false"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Node20 was added to Actions Runner on v2.308.0 and Node16 reaches end of life soon on 11 Sep 2023.

Therefore, This PR updates the default runtime to node20. Sorry I forgot to do it yesterday when bumping `actions/checkout` version.
