### PR TITLE
Provide multi-arch runner images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,7 @@ jobs:
           - name: kde-6.2
             packages: org.kde.Platform//6.2 org.kde.Sdk//6.2
             remote: flathub
-          
+
           - name: kde-6.3
             packages: org.kde.Platform//6.3 org.kde.Sdk//6.3
             remote: flathub
@@ -111,6 +111,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
         with:
@@ -131,6 +134,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           pull: true
           push: true
           tags: localhost:5000/fedora-base:latest
@@ -155,5 +159,6 @@ jobs:
           allow: security.insecure
           context: .
           file: ${{ matrix.runtime.name }}.Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}


### PR DESCRIPTION
This allows running the builder action on a native aarch64 runner which is much faster than using QEMU.

Based on the [official docs](https://docs.docker.com/build/ci/github-actions/multi-platform/).

Fixes #178