### PR TITLE
Update flat-manager to v6 in readme deployment stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ jobs:
         bundle: palette.flatpak
         manifest-path: org.gnome.zbrown.Palette.yml
         cache-key: flatpak-builder-${{ github.sha }}
-    - uses: flatpak/flatpak-github-actions/flat-manager@v4
+    - uses: flatpak/flatpak-github-actions/flat-manager@v6
       name: "Deploy"
       with:
         repository: elementary


### PR DESCRIPTION
flatpak/flatpak-github-actions/flat-manager should be the latest version in the readme too.

end-of-life does not work with v4, as it was added later. 

On another note: end-of-life is broken on v6 too as it was fixed a couple of days after the latest tag was created (#160) so I had to use @​master to use it.