### PR TITLE
Add arm64 images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -165,3 +165,4 @@ jobs:
           file: ${{ matrix.runtime.name }}.Dockerfile
           push: true
           tags: bilelmoussaoui/flatpak-github-actions:${{ matrix.runtime.name }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,7 +158,7 @@ jobs:
           RUN --security=insecure flatpak install -y --noninteractive ${{matrix.runtime.remote}} ${{ matrix.runtime.packages }}
 
       - name: Build & push the ${{ matrix.runtime.name }} image to Docker Hub
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v6
         with:
           allow: security.insecure
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,6 +119,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU for cross-compilation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: aarch64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
         with:
@@ -142,6 +147,7 @@ jobs:
           pull: true
           push: true
           tags: localhost:5000/fedora-base:latest
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2.1.0


### PR DESCRIPTION
This will allow the `flatpak-builder` action to be used on native ARM64 runners once they reach full release.