### PR TITLE
Add Freedesktop SDK 24.08

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,10 @@ jobs:
             packages: org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
             remote: flathub
 
+          - name: freedesktop-24.08
+            packages: org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+            remote: flathub
+
           - name: gnome-3.38
             packages: org.gnome.Platform//3.38 org.gnome.Sdk//3.38
             remote: flathub

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ You can specify the specific runtime you need to use through the image tags:
 | Freedesktop SDK | 21.08   | `freedesktop-21.08` | `image: bilelmoussaoui/flatpak-github-actions:freedesktop-21.08` |
 | Freedesktop SDK | 22.08   | `freedesktop-22.08` | `image: bilelmoussaoui/flatpak-github-actions:freedesktop-22.08` |
 | Freedesktop SDK | 23.08   | `freedesktop-23.08` | `image: bilelmoussaoui/flatpak-github-actions:freedesktop-23.08` |
+| Freedesktop SDK | 24.08   | `freedesktop-24.08` | `image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08` |
 | GNOME           | 3.38    | `gnome-3.38`        | `image: bilelmoussaoui/flatpak-github-actions:gnome-3.38`        |
 | GNOME           | 40    | `gnome-40`        | `image: bilelmoussaoui/flatpak-github-actions:gnome-40`        |
 | GNOME           | 41    | `gnome-41`        | `image: bilelmoussaoui/flatpak-github-actions:gnome-41`        |


### PR DESCRIPTION
Freedesktop SDK 24.08 was released today: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-24.08.0