### PR TITLE
Add circe-24.08

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,6 +125,10 @@ jobs:
             packages: io.elementary.BaseApp//juno-20.08 org.gnome.Platform//3.38 org.gnome.Sdk//3.38
             remote: flathub
 
+          - name: elementary-circe-24.08
+            packages: io.elementary.BaseApp//circe-24.08 org.gnome.Platform//47 org.gnome.Sdk//47
+            remote: flathub
+
     services:
       registry:
         image: registry:latest

--- a/README.md
+++ b/README.md
@@ -231,3 +231,4 @@ You can specify the specific runtime you need to use through the image tags:
 | KDE             | 6.7     | `kde-6.7`          | `image: bilelmoussaoui/flatpak-github-actions:kde-6.7`          |
 | KDE             | 6.8     | `kde-6.8`          | `image: bilelmoussaoui/flatpak-github-actions:kde-6.8`          |
 | elementary BaseApp             | juno    | `juno`          | `image: bilelmoussaoui/flatpak-github-actions:elementary-juno`          |
+| elementary BaseApp             | circe 24.08    | `circe-24.08`          | `image: bilelmoussaoui/flatpak-github-actions:elementary-circe-24.08`          |


### PR DESCRIPTION
[`juno` branch of elementary BaseApp](https://github.com/flathub/io.elementary.BaseApp/tree/branch/juno-20.08) is no longer actively maintained and stale. So, add [`circe-24.08` branch of elementary BaseApp](https://github.com/flathub/io.elementary.BaseApp/tree/branch/circe-24.08) instead.
