### PR TITLE
Fix restore cache keys to actually include arch

### DIFF
--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -328,7 +328,7 @@ const prepareBuild = async (config) => {
       CACHE_PATH,
       `${cacheKey}`,
       [
-        `flatpak-builder-${this.arch}`
+        `flatpak-builder-${config.arch}`
       ]
     )
     if (cacheHitKey !== undefined) {


### PR DESCRIPTION
"this" does not include the Configuration class properties outside of the class definition scope. Instead use the config object.