### PR TITLE
Specify full URL policy when mirroring screenshots

### DIFF
--- a/flatpak-builder/index.js
+++ b/flatpak-builder/index.js
@@ -231,6 +231,7 @@ const build = async (manifest, manifestPath, cacheHitKey, config) => {
   }
   if (config.mirrorScreenshotsUrl) {
     args.push(`--mirror-screenshots-url=${config.mirrorScreenshotsUrl}`)
+    args.push('--compose-url-policy=full')
   }
   if (config.gpgSign) {
     args.push(`--gpg-sign=${config.gpgSign}`)


### PR DESCRIPTION
This maintains the behaviour that flatpak-builder had in the Flathub image but uses the newly introduced argument instead of the downstream patch

See https://github.com/flatpak/flatpak-builder/pull/652


We will need a new v6 tag with this.